### PR TITLE
Add RegExp support

### DIFF
--- a/conditional_fields.api.inc
+++ b/conditional_fields.api.inc
@@ -173,7 +173,7 @@ function conditional_fields_form_after_build($form, FormStateInterface &$form_st
           $values[$options['condition']] = $options['value_form'];
         }
         elseif ($options['values_set'] == CONDITIONAL_FIELDS_DEPENDENCY_VALUES_REGEX) {
-          $values[$options['condition']] = $options['value'];
+          $values[$options['condition']] = ['regex' => $options['regex'] ];
         }
         elseif ($options['values_set'] == CONDITIONAL_FIELDS_DEPENDENCY_VALUES_AND) {
           $values_array = explode("\r\n", $options['values']);
@@ -348,6 +348,10 @@ function conditional_fields_form_after_build($form, FormStateInterface &$form_st
  * @see conditional_fields_form_validate()
  */
 function conditional_fields_dependent_validate($element, FormStateInterface &$form_state, $form) {
+  if (!isset($form['#conditional_fields'])) {
+    return;
+  }
+
   $dependent = $form['#conditional_fields'][reset($element['#array_parents'])];
 
   // Check if this field's dependencies were triggered.
@@ -594,6 +598,8 @@ function conditional_fields_form_field_get_values($element, FormStateInterface $
  * @param $context
  *   'edit' if $values are extracted from $form_state or 'view' if
  *   $values are extracted from an entity.
+ *
+ * @return bool
  */
 function conditional_fields_evaluate_dependency($context, $values, $options) {
   if ($options['values_set'] == CONDITIONAL_FIELDS_DEPENDENCY_VALUES_WIDGET) {
@@ -705,7 +711,7 @@ function conditional_fields_evaluate_dependency($context, $values, $options) {
   // Regular expression method.
   if ($options['values_set'] == CONDITIONAL_FIELDS_DEPENDENCY_VALUES_REGEX) {
     foreach ($reference_values as $reference_value) {
-      if (!preg_match('/' . $options['value']['RegExp'] . '/', $reference_value)) {
+      if (!preg_match('/' . $options['regex'] . '/', $reference_value)) {
         return FALSE;
       }
     }

--- a/js/conditional_fields.js
+++ b/js/conditional_fields.js
@@ -162,7 +162,6 @@ Drupal.behaviors.autocompleteChooseTrigger = {
         $(context).find('.form-autocomplete').each(function() {
             var $input = $(this);
             $(this).on('input', function() {
-                console.log($input);
                 $(context).ajaxComplete(function() {
                     $(context).find('.ui-autocomplete li').each(function() {
                         $(this).on('click', function() {
@@ -176,6 +175,26 @@ Drupal.behaviors.autocompleteChooseTrigger = {
             });
         });
     }
+};
+
+/**
+ * Adds RegEx support
+ * https://www.drupal.org/node/1340616
+ */
+Drupal.behaviors.statesModification = {
+  weight: -10,
+  attach: function (context, settings) {
+    if (Drupal.states) {
+      Drupal.states.Dependent.comparisons.Object = function (reference, value) {
+        if ('regex' in reference) {
+          return (new RegExp(reference.regex, reference.flags)).test(value);
+        }
+        else {
+          return reference.indexOf(value) !== false;
+        }
+      }
+    }
+  }
 };
 
 })(jQuery);

--- a/src/Form/ConditionalFieldEditForm.php
+++ b/src/Form/ConditionalFieldEditForm.php
@@ -187,7 +187,7 @@ class ConditionalFieldEditForm extends FormBase {
       '#description' => $this->t('The dependency is triggered when all the values of the dependee %field match the regular expression. The expression should be valid both in PHP and in Javascript. Do not include delimiters.', ['%field' => $label]) . '<br>' . $this->t('Note: If the dependee has allowed values, these are actually the keys, not the labels, of those values.'),
       '#maxlength' => 2048,
       '#size' => 120,
-      '#default_value' => isset($settings['value']['RegExp']) ? $settings['value']['RegExp'] : '',
+      '#default_value' => $settings['regex'] ?? '',
       '#states' => [
         'visible' => [
           ':input[name="values_set"]' => ['value' => (string) CONDITIONAL_FIELDS_DEPENDENCY_VALUES_REGEX],
@@ -258,7 +258,6 @@ class ConditionalFieldEditForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // TODO: Inprogress.
     $values = $form_state->cleanValues()->getValues();
-
     $uuid = $values['uuid'];
     $entity_type = $values['entity_type'];
     $bundle = $values['bundle'];


### PR DESCRIPTION
Contains various tweaks:

- fixes RegEx default value in the edit form
- modifies the `#states` value
- extends the JS to include regex support